### PR TITLE
more generic pixel size handling

### DIFF
--- a/src/harvesters/_private/frontend/canvas.py
+++ b/src/harvesters/_private/frontend/canvas.py
@@ -33,8 +33,7 @@ from genicam2.gentl import PAYLOADTYPE_INFO_IDS
 
 # Local application/library specific imports
 from harvesters._private.core.helper.system import is_running_on_macos
-from harvesters.pfnc import component_8bit_formats, component_10bit_formats, \
-    component_12bit_formats, component_14bit_formats, component_16bit_formats
+from harvesters.pfnc import calc_pixel_size, is_pixel_custom
 
 
 
@@ -213,19 +212,15 @@ class Canvas(app.Canvas):
                     exponent = 0
 
                     #
-                    pixel_format = buffer.payload.components[0].data_format
-                    if pixel_format in component_8bit_formats:
-                        pass
-                    elif pixel_format in component_10bit_formats:
-                        exponent = 2
-                    elif pixel_format in component_12bit_formats:
-                        exponent = 4
-                    elif pixel_format in component_14bit_formats:
-                        exponent = 6
-                    elif pixel_format in component_16bit_formats:
-                        exponent = 8
-                    else:
+                    pixel_format_value = buffer.payload.components[0].data_format_value
+                    if is_pixel_custom(pixel_format_value):
                         update = False
+                    else:
+                        pixel_size = calc_pixel_size(pixel_format_value)
+                        if 8 <= pixel_size <= 16:
+                            exponent = pixel_size - 8
+                        else:
+                            update = False
 
                     if update:
                         # Convert each data to an 8bit.

--- a/src/harvesters/_private/frontend/canvas.py
+++ b/src/harvesters/_private/frontend/canvas.py
@@ -33,7 +33,7 @@ from genicam2.gentl import PAYLOADTYPE_INFO_IDS
 
 # Local application/library specific imports
 from harvesters._private.core.helper.system import is_running_on_macos
-from harvesters.pfnc import calc_pixel_size, is_pixel_custom
+from harvesters.pfnc import get_pixel_size, is_custom
 
 
 
@@ -213,10 +213,10 @@ class Canvas(app.Canvas):
 
                     #
                     pixel_format_value = buffer.payload.components[0].data_format_value
-                    if is_pixel_custom(pixel_format_value):
+                    if is_custom(pixel_format_value):
                         update = False
                     else:
-                        pixel_size = calc_pixel_size(pixel_format_value)
+                        pixel_size = get_pixel_size(pixel_format_value)
                         if 8 <= pixel_size <= 16:
                             exponent = pixel_size - 8
                         else:

--- a/src/harvesters/core.py
+++ b/src/harvesters/core.py
@@ -460,9 +460,9 @@ class Component2D(ComponentBase):
         return value
 
     @property
-    def data_format(self):
+    def data_format_value(self):
         """
-        Returns the data type of the data component.
+        Returns the data type of the data component as integer value.
         :return:
         """
         try:
@@ -472,7 +472,15 @@ class Component2D(ComponentBase):
                 value = self._buffer.pixel_format
         except InvalidParameterException:
             value = self._node_map.PixelFormat.value
-        return symbolics[value]
+        return value
+
+    @property
+    def data_format(self):
+        """
+        Returns the data type of the data component as string.
+        :return:
+        """
+        return symbolics[self.data_format_value]
 
     @property
     def delivered_image_height(self):

--- a/src/harvesters/pfnc.py
+++ b/src/harvesters/pfnc.py
@@ -271,6 +271,16 @@ symbolics = {
     0x02180103: 'YCbCr2020_422_12p_CbYCrY',
 }
 
+pfnc_custom = 0x80000000
+pfnc_pixel_size_mask = 0x00FF0000
+pfnc_pixel_size_shift = 16
+
+def calc_pixel_size(pixel_format_value):
+    return (pixel_format_value & pfnc_pixel_size_mask) >> pfnc_pixel_size_shift
+
+def is_pixel_custom(pixel_format_value):
+    return (pixel_format_value & pfnc_custom) == pfnc_custom
+
 mono_formats = ['Mono8', 'Mono10', 'Mono12', 'Mono14', 'Mono16']
 
 rgb_formats = [

--- a/src/harvesters/pfnc.py
+++ b/src/harvesters/pfnc.py
@@ -25,6 +25,9 @@
 # Local application/library specific imports
 
 
+# We create the following symbolics from the official PFNC table so the
+# numeric values are all capitalized but this is an exception: We usually
+# go with lower case in other Python files.
 symbolics = {
     # As of 17-Feb-2017
     0x01080001: 'Mono8',
@@ -272,14 +275,18 @@ symbolics = {
 }
 
 pfnc_custom = 0x80000000
-pfnc_pixel_size_mask = 0x00FF0000
+pfnc_pixel_size_mask = 0x00ff0000
 pfnc_pixel_size_shift = 16
 
-def calc_pixel_size(pixel_format_value):
-    return (pixel_format_value & pfnc_pixel_size_mask) >> pfnc_pixel_size_shift
 
-def is_pixel_custom(pixel_format_value):
+def get_pixel_size(pixel_format_value):
+    return (pixel_format_value & pfnc_pixel_size_mask) >> \
+           pfnc_pixel_size_shift
+
+
+def is_custom(pixel_format_value):
     return (pixel_format_value & pfnc_custom) == pfnc_custom
+
 
 mono_formats = ['Mono8', 'Mono10', 'Mono12', 'Mono14', 'Mono16']
 


### PR DESCRIPTION
should work for the already defined formats as before and include many others.

Can't think of a case when this would fail right now, but still: it means that many more formats would be displayed if they pass the initial "filter" (are in `component_2d_formats`).

Also I guess the component_xbit_formats lists could then be removed from pfnc.py

Tested with `mono8` and `Confidence8` so far.
For the latter it needs to be added to `component_2d_formats` instead of `component_1d_formats` as well.