### PR TITLE
Support roboception formats

### DIFF
--- a/src/harvesters/pfnc.py
+++ b/src/harvesters/pfnc.py
@@ -304,6 +304,7 @@ uint8_formats = [
     'Mono8',
     'RGB8', 'RGB8Packed', 'RGBa8',
     'BayerGR8', 'BayerGB8', 'BayerRG8', 'BayerBG8',
+    'Confidence8'
 ]
 
 uint16_formats = [
@@ -313,6 +314,7 @@ uint16_formats = [
     'BayerGR10', 'BayerGB10', 'BayerRG10', 'BayerBG10',
     'BayerGR12', 'BayerGB12', 'BayerRG12', 'BayerBG12',
     'BayerGR16', 'BayerRG16', 'BayerGB16', 'BayerBG16',
+    'Coord3D_C16'
 ]
 
 uint32_formats = [
@@ -355,7 +357,6 @@ component_16bit_formats = [
 component_1d_formats = [
     'Confidence1',
     'Confidence1p',
-    'Confidence8',
     'Confidence16',
     'Confidence32f',
 ]
@@ -371,4 +372,6 @@ component_2d_formats = [
     'Coord3D_A32f',
     'Coord3D_B32f',
     'Coord3D_C32f',
+    'Coord3D_C16',
+    'Confidence8',
 ]


### PR DESCRIPTION
This PR is mainly meant for discussion and basically includes #35 

Additionally it adds "support" for Confidence8 and Coord3D_C16 pixel formats.
This doesn't yet apply any nice scaling for the Coord3D_C16 format if it is a Disparity, but is already "displayable".