### PR TITLE
clarify meaning of effective pixel size and useful bits per pixel

### DIFF
--- a/src/harvesters/_private/frontend/canvas.py
+++ b/src/harvesters/_private/frontend/canvas.py
@@ -33,7 +33,7 @@ from genicam2.gentl import PAYLOADTYPE_INFO_IDS
 
 # Local application/library specific imports
 from harvesters._private.core.helper.system import is_running_on_macos
-from harvesters.pfnc import get_pixel_size, is_custom, get_effective_data_size
+from harvesters.pfnc import is_custom, get_bits_per_pixel
 
 
 class Canvas(app.Canvas):
@@ -62,7 +62,7 @@ class Canvas(app.Canvas):
         As far as we know, Vispy refreshes the canvas every 1/30 sec at the
         fastest no matter which faster number is specified. If we set any
         value which is greater than 30, then Vispy's callback is randomly
-        called. 
+        called.
         """
 
         self._vertex_shader = vertex_shader if vertex_shader else """
@@ -223,8 +223,8 @@ class Canvas(app.Canvas):
                         update = False
                     else:
                         data_format = buffer.payload.components[0].data_format
-                        effective_data_size = get_effective_data_size(data_format)
-                        exponent = effective_data_size - 8
+                        bpp = get_bits_per_pixel(data_format)
+                        exponent = bpp - 8
 
                     if update:
                         # Convert each data to an 8bit.


### PR DESCRIPTION
also actually return a default size returned if pixel format is not "known".

We could also return None in that case, to make it explicit that this is not known.
Or we could return the effective size (so including padding) if not in our list of known ones.

Also added `Confidence8` and `Coord3D_C16` to known component formats.