### PR TITLE
Added support for snapshot, saving all images with Pillow, and path to where images are saved

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setuptools.setup(
     # Location where the package may be downloaded:
     download_url='https://pypi.org/project/harvesters/',
     # A list of required Python modules:
-    install_requires=['genicam2', 'numpy'],
+    install_requires=['genicam2', 'numpy', 'Pillow'],
     #
     license='Apache Software License V2.0',
     # A detailed description of the package:


### PR DESCRIPTION
Hi Kazunari, I needed a software solution to record video from an USB3 vision compliant IDS camera. I added some features here and in your GUI repo to allow for all acquired images to be saved to disk or snapshots to be taken when the acquisition is paused (stopped drawing). 

It's based off the 0.2.11 release tag because it looks like the later changes are incompatible with the GUI version.