### PR TITLE
Strip leading slashes from local: xml url

### DIFF
--- a/src/harvesters/core.py
+++ b/src/harvesters/core.py
@@ -2402,6 +2402,8 @@ def _retrieve_file_path(*, port=None, url=None, file_path=None, logger=None, xml
         if location == 'local':
             file_name, address, size = others.split(';')
             address = int(address, 16)
+            # Remove optional /// after local: See section 4.1.2 in GenTL v1.4 Standard
+            file_name = file_name.lstrip('/')
 
             # It may specify the schema version.
             delimiter = '?'


### PR DESCRIPTION
Fixes: #126

According to the GenICam standard 1.4, the /// after local: should be a valid configuration.  But we need to strip it out so it doesn't affect saving the file on the local machine.

4.1.2.1 Module Register Map (Recommended)
A URL in the form “local:[///]filename.extension;address;length[?SchemaVersion=x.x.x]”
indicates that the XML description file is located in the module’s virtual register map. The
square brackets are optional.