### PR TITLE
BUFFER_INFO_TIMESTAMP is not returned when DEVICE_INFO_TIMESTAMP_FREQUENCY is not available.

### DIFF
--- a/src/harvesters/core.py
+++ b/src/harvesters/core.py
@@ -1188,19 +1188,13 @@ class Buffer:
         :getter: Returns itself.
         :type: int
         """
-        timestamp = 0
         try:
             timestamp = self._buffer.timestamp_ns
         except GenericException:
             try:
-                _ = self.timestamp_frequency
+                timestamp = self._buffer.timestamp
             except GenericException:
-                pass
-            else:
-                try:
-                    timestamp = self._buffer.timestamp
-                except GenericException:
-                    timestamp = 0
+                timestamp = 0
 
         return timestamp
 


### PR DESCRIPTION
Hi Kazunari,

i tried to access the buffer information "BUFFER_INFO_TIMESTAMP", but i could only access it with direct access to the protected buffer.

The buffer provide 3 function for timestamp informations: 

- timestamp_ns() for "BUFFER_INFO_TIMESTAMP_NS"
- timestamp_frequency()
- timestamp() 

but no direct access for "BUFFER_INFO_TIMESTAMP".

I would suggest, that timestamp() returns "BUFFER_INFO_TIMESTAMP" when this is "0", it returns "BUFFER_INFO_TIMESTAMP_NS".