### PR TITLE
_dev_alfred_issue_269_and_276

### DIFF
--- a/src/harvesters/core.py
+++ b/src/harvesters/core.py
@@ -2304,7 +2304,10 @@ class ImageAcquirer:
                     self._chunk_adapter.attach_buffer(
                         buffer.raw_buffer, buffer.chunk_data_info_list)
                 else:
-                    self._chunk_adapter.attach_buffer(buffer.raw_buffer)
+                    if (len(buffer.raw_buffer) > buffer.delivered_chunk_payload_size):
+                        self._chunk_adapter.attach_buffer(buffer.raw_buffer[:buffer.delivered_chunk_payload_size])
+                    else:
+                        self._chunk_adapter.attach_buffer(buffer.raw_buffer)
             except GenericException as e:
                 _logger.error(e, exc_info=True)
             else:


### PR DESCRIPTION
There was a problem for some with fetching buffers containing chunk data. I believe this is the cause of issue #269 and possibly also #276. 

The problem appears to be the buffer containing padding after the end of the chunk data and tag. To solve the issue everything in the buffer after chunk payload size can be removed since chunk payload size should point to the very end of the chunk tag, which should be at the very end of the buffer.

self._chunk_adapter.attach_buffer(buffer.raw_buffer[:buffer.delivered_chunk_payload_size]) is enough to solve the issue, however the if statment should have better performance (if slicing the buffer creates a copy of it).