### PR TITLE
Allow interface node_map before connecting camera

### DIFF
--- a/src/harvesters/_private/core/port.py
+++ b/src/harvesters/_private/core/port.py
@@ -19,13 +19,224 @@
 
 
 # Standard library imports
+import io
+from datetime import datetime
+import os
+import sys
+import pathlib
+from typing import Optional, Dict
+import ntpath
+import tempfile
+import re
+from urllib.parse import urlparse
 
 # Related third party imports
 from genicam.genapi import AbstractPort
 from genicam.genapi import EAccessMode
 from genicam.gentl import Port
+from genicam.genapi import NodeMap
+from genicam.genapi import GenericException as GenApi_GenericException
+from genicam.genapi import LogicalErrorException
 
 # Local application/library specific imports
+from harvesters.util.logging import get_logger
+from harvesters._private.core.helper.system import is_running_on_windows
+
+
+_logger = get_logger(name=__name__)
+
+
+def _get_port_connected_node_map(
+        port, file_path: Optional[str] = None,
+        xml_dir_to_store: Optional[str] = None,
+        file_dict: Dict[str, bytes] = None, do_clean_up: bool = True):
+    global _logger
+
+    assert port
+
+    node_map = NodeMap()
+
+    file_path = _retrieve_file_path(
+        port=port, file_path_to_load=file_path,
+        xml_dir_to_store=xml_dir_to_store, file_dict=file_dict)
+
+    if file_path is not None:
+        # Every valid (zipped) XML file MUST be parsed as expected and the
+        # method returns the file path where the file is located:
+        # Then load the XML file content on the node map object.
+        has_valid_file = True
+
+        # In this case, the file has been identified as a Zip file but
+        # has been diagnosed as BadZipFile due to a technical reason.
+        # Let the NodeMap object load the file from the path:
+        try:
+            node_map.load_xml_from_zip_file(file_path)
+        except GenApi_GenericException:
+            try:
+                node_map.load_xml_from_file(file_path)
+            except GenApi_GenericException as e:
+                if file_dict:
+                    if do_clean_up:
+                        _remove_intermediate_file(file_path)
+                    _logger.warning(e, exc_info=True)
+                    raise
+                else:
+                    _logger.warning(e, exc_info=True)
+
+        if do_clean_up:
+            _remove_intermediate_file(file_path)
+
+        if has_valid_file:
+            concrete_port = ConcretePort(port)
+            node_map.connect(concrete_port, port.name)
+
+    return node_map
+
+
+def _remove_intermediate_file(file_path: str):
+    global _logger
+    os.remove(file_path)
+    _logger.debug('deleted: {0}'.format(file_path))
+
+
+def _retrieve_file_path(
+        *, port: Optional[Port] = None, url: Optional[str] = None,
+        file_path_to_load: Optional[str] = None,
+        xml_dir_to_store: Optional[str] = None,
+        file_dict: Dict[str, bytes] = None):
+    global _logger
+
+    if file_path_to_load:
+        if not os.path.exists(file_path_to_load):
+            raise LogicalErrorException(
+                '{} does not exist.'.format(file_path_to_load))
+    else:
+        if url is None:
+            if len(port.url_info_list) > 0:
+                url = port.url_info_list[0].url
+            else:
+                raise LogicalErrorException(
+                    'The target port does not hold any URL.')
+
+        _logger.debug('fetched url: {}'.format(url))
+
+        location, others = url.split(':', 1)
+        location = location.lower()
+
+        if location == 'local':
+            file_name, address, size = others.split(';')
+            address = int(address, 16)
+            # Remove optional /// after local: See section 4.1.2 in GenTL
+            # v1.4 Standard
+            file_name = file_name.lstrip('/')
+
+            delimiter = '?'
+            if delimiter in size:
+                size, _ = size.split(delimiter)
+            size = int(size, 16)  # From Hex to Dec
+
+            size, binary_data = port.read(address, size)
+
+            file_path_to_load = _save_file(
+                xml_dir_to_store=xml_dir_to_store, file_name=file_name,
+                binary_data=binary_data, file_dict=file_dict)
+
+        elif location == 'file':
+            file_path_to_load = urlparse(url).path
+            if is_running_on_windows():
+                file_path_to_load = re.sub(r'^/+', '', file_path_to_load)
+
+        elif location == 'http' or location == 'https':
+            raise NotImplementedError(
+                'Failed to parse URL {}: Harvester has not supported '
+                'downloading a device description file from vendor '
+                'web site. If you must rely on the current condition,'
+                'just try to make a request to the Harvester '
+                'maintainer.'.format(url))
+        else:
+            raise LogicalErrorException(
+                'Failed to parse URL {}: Unknown format.'.format(url))
+
+    return file_path_to_load
+
+
+def _save_file(
+            *, xml_dir_to_store: Optional[str] = None,
+            file_name: Optional[str] = None, binary_data=None,
+            file_dict: Dict[str, bytes] = None):
+    global _logger
+
+    assert binary_data
+    assert file_name
+
+    bytes_io = io.BytesIO(binary_data)
+
+    if xml_dir_to_store is not None:
+        if not os.path.exists(xml_dir_to_store):
+            os.makedirs(xml_dir_to_store)
+    else:
+        xml_dir_to_store = tempfile.mkdtemp(
+            prefix=datetime.now().strftime('%Y%m%d%H%M%S_'))
+
+    _file_name = ntpath.basename(file_name)
+    file_path = os.path.join(xml_dir_to_store, _file_name)
+
+    mode = 'w+'
+    data_to_write = bytes_io.getvalue()
+    if pathlib.Path(file_path).suffix.lower() != '.zip':
+        data_to_write = _drop_padding_data(
+            data_to_write, file_name=_file_name, file_dict=file_dict)
+
+    try:
+        with open(file_path, mode + 'b') as f:
+            f.write(data_to_write)
+    except UnicodeEncodeError:
+        # Probably you've caught "UnicodeEncodeError: 'charmap' codec can't
+        # encode characters"; the file must be a text file:
+        try:
+            with io.open(file_path, mode, encoding="utf-8") as f:
+                f.write(data_to_write)
+        except:
+            e = sys.exc_info()[0]
+            _logger.error(e, exc_info=True)
+            raise
+    except:
+        e = sys.exc_info()[0]
+        _logger.error(e, exc_info=True)
+        raise
+    else:
+        _logger.debug("created: {}".format(file_path))
+
+    return file_path
+
+
+def _drop_padding_data(
+        data_to_write: bytes, *, file_name: str = None,
+        file_dict: Dict[str, bytes] = None):
+    global _logger
+
+    assert data_to_write
+
+    data_to_be_found = b'\x00'
+    if file_dict and file_name:
+        result = None
+        key = None
+        for pattern in file_dict.keys():
+            result = re.search(pattern, file_name)
+            if result:
+                key = pattern
+                break
+        if result and key:
+            data_to_be_found = file_dict[key]
+
+    pos = data_to_write.find(data_to_be_found)
+    if pos != -1:
+        _logger.debug(
+            "an x00 has been found in {}; "
+            "the array will be truncated.".format(file_name))
+        return data_to_write[:pos]
+    else:
+        return data_to_write
 
 
 class ConcretePort(AbstractPort):

--- a/src/harvesters/_private/core/port.py
+++ b/src/harvesters/_private/core/port.py
@@ -33,10 +33,11 @@ from urllib.parse import urlparse
 # Related third party imports
 from genicam.genapi import AbstractPort
 from genicam.genapi import EAccessMode
-from genicam.gentl import Port
 from genicam.genapi import NodeMap
 from genicam.genapi import GenericException as GenApi_GenericException
 from genicam.genapi import LogicalErrorException
+
+from genicam.gentl import Port
 
 # Local application/library specific imports
 from harvesters.util.logging import get_logger
@@ -47,7 +48,7 @@ _logger = get_logger(name=__name__)
 
 
 def _get_port_connected_node_map(
-        port, file_path: Optional[str] = None,
+        *, port: Optional[Port] = None, file_path: Optional[str] = None,
         xml_dir_to_store: Optional[str] = None,
         file_dict: Dict[str, bytes] = None, do_clean_up: bool = True):
     global _logger

--- a/src/harvesters/core.py
+++ b/src/harvesters/core.py
@@ -22,35 +22,27 @@
 from __future__ import annotations
 from collections.abc import Iterable
 from ctypes import CDLL
-from datetime import datetime
 from enum import IntEnum
-import io
 import json
 from logging import Logger
 from math import ceil, isclose
-import ntpath
 import os
-import pathlib
 from queue import Queue
 from queue import Full, Empty
-import re
 import signal
 import sys
 from threading import Lock, Thread, Event
 from threading import current_thread, main_thread
 import time
 from typing import Union, List, Optional, Dict
-from urllib.parse import urlparse
 from warnings import warn
 import weakref
-import tempfile
 
 # Related third party imports
 import numpy
 
 from genicam.genapi import NodeMap
 from genicam.genapi import GenericException as GenApi_GenericException
-from genicam.genapi import LogicalErrorException
 from genicam.genapi import ChunkAdapterGeneric, ChunkAdapterU3V, \
     ChunkAdapterGEV
 
@@ -64,10 +56,8 @@ from genicam.gentl import EventToken, Port, PIXELFORMAT_NAMESPACE_IDS
 from genicam.gentl import Buffer as Buffer_
 
 # Local application/library specific imports
-from harvesters._private.core.port import ConcretePort
 from harvesters._private.core.port import _get_port_connected_node_map
 from harvesters._private.core.statistics import Statistics
-from harvesters._private.core.helper.system import is_running_on_windows
 from harvesters.util.logging import get_logger
 from harvesters.util.pfnc import dict_by_names, dict_by_ints
 from harvesters.util.pfnc import Dictionary, _PixelFormat

--- a/src/harvesters/core.py
+++ b/src/harvesters/core.py
@@ -65,6 +65,7 @@ from genicam.gentl import Buffer as Buffer_
 
 # Local application/library specific imports
 from harvesters._private.core.port import ConcretePort
+from harvesters._private.core.port import _get_port_connected_node_map
 from harvesters._private.core.statistics import Statistics
 from harvesters._private.core.helper.system import is_running_on_windows
 from harvesters.util.logging import get_logger
@@ -1371,7 +1372,7 @@ class ImageAcquirer:
         node_maps = []
         for (file_path_, port) in zip(file_paths, ports):
             try:
-                node_map_ = self._get_port_connected_node_map(
+                node_map_ = _get_port_connected_node_map(
                     port=port, xml_dir_to_store=self._xml_dir,
                     file_path=file_path_, file_dict=self._file_dict,
                     do_clean_up=self._do_clean_up)
@@ -1837,7 +1838,7 @@ class ImageAcquirer:
 
             #
             try:
-                node_map = self._get_port_connected_node_map(
+                node_map = _get_port_connected_node_map(
                     port=_data_stream.port, file_dict=file_dict,
                     do_clean_up=self._do_clean_up)
             except GenTL_GenericException as e:
@@ -1855,120 +1856,6 @@ class ImageAcquirer:
 
             self._event_new_buffer_managers.append(
                 EventManagerNewBuffer(event_token))
-
-    def _get_port_connected_node_map(
-            self, *, port: Optional[Port] = None,
-            file_path: Optional[str] = None,
-            xml_dir_to_store: Optional[str] = None,
-            file_dict: Dict[str, bytes] = None, do_clean_up: bool = True):
-        global _logger
-
-        assert port
-
-        node_map = NodeMap()
-
-        file_path = self._retrieve_file_path(
-            port=port, file_path_to_load=file_path,
-            xml_dir_to_store=xml_dir_to_store, file_dict=file_dict)
-
-        if file_path is not None:
-            # Every valid (zipped) XML file MUST be parsed as expected and the
-            # method returns the file path where the file is located:
-            # Then load the XML file content on the node map object.
-            has_valid_file = True
-
-            # In this case, the file has been identified as a Zip file but
-            # has been diagnosed as BadZipFile due to a technical reason.
-            # Let the NodeMap object load the file from the path:
-            try:
-                node_map.load_xml_from_zip_file(file_path)
-            except GenApi_GenericException:
-                try:
-                    node_map.load_xml_from_file(file_path)
-                except GenApi_GenericException as e:
-                    if file_dict:
-                        if do_clean_up:
-                            self._remove_intermediate_file(file_path)
-                        _logger.warning(e, exc_info=True)
-                        raise
-                    else:
-                        _logger.warning(e, exc_info=True)
-
-            if do_clean_up:
-                self._remove_intermediate_file(file_path)
-
-            if has_valid_file:
-                concrete_port = ConcretePort(port)
-                node_map.connect(concrete_port, port.name)
-
-        return node_map
-
-    @staticmethod
-    def _remove_intermediate_file(file_path: str):
-        global _logger
-        os.remove(file_path)
-        _logger.debug('deleted: {0}'.format(file_path))
-
-    @staticmethod
-    def _retrieve_file_path(
-            *, port: Optional[Port] = None, url: Optional[str] = None,
-            file_path_to_load: Optional[str] = None,
-            xml_dir_to_store: Optional[str] = None,
-            file_dict: Dict[str, bytes] = None):
-        global _logger
-
-        if file_path_to_load:
-            if not os.path.exists(file_path_to_load):
-                raise LogicalErrorException(
-                    '{} does not exist.'.format(file_path_to_load))
-        else:
-            if url is None:
-                if len(port.url_info_list) > 0:
-                    url = port.url_info_list[0].url
-                else:
-                    raise LogicalErrorException(
-                        'The target port does not hold any URL.')
-
-            _logger.debug('fetched url: {}'.format(url))
-
-            location, others = url.split(':', 1)
-            location = location.lower()
-
-            if location == 'local':
-                file_name, address, size = others.split(';')
-                address = int(address, 16)
-                # Remove optional /// after local: See section 4.1.2 in GenTL
-                # v1.4 Standard
-                file_name = file_name.lstrip('/')
-
-                delimiter = '?'
-                if delimiter in size:
-                    size, _ = size.split(delimiter)
-                size = int(size, 16)  # From Hex to Dec
-
-                size, binary_data = port.read(address, size)
-
-                file_path_to_load = _save_file(
-                    xml_dir_to_store=xml_dir_to_store, file_name=file_name,
-                    binary_data=binary_data, file_dict=file_dict)
-
-            elif location == 'file':
-                file_path_to_load = urlparse(url).path
-                if is_running_on_windows():
-                    file_path_to_load = re.sub(r'^/+', '', file_path_to_load)
-
-            elif location == 'http' or location == 'https':
-                raise NotImplementedError(
-                    'Failed to parse URL {}: Harvester has not supported '
-                    'downloading a device description file from vendor '
-                    'web site. If you must rely on the current condition,'
-                    'just try to make a request to the Harvester '
-                    'maintainer.'.format(url))
-            else:
-                raise LogicalErrorException(
-                    'Failed to parse URL {}: Unknown format.'.format(url))
-
-        return file_path_to_load
 
     def start_image_acquisition(self, run_in_background=False):
         """
@@ -2446,85 +2333,6 @@ class ImageAcquirer:
 
         while not self._queue.empty():
             _ = self._queue.get_nowait()
-
-
-def _save_file(
-        *, xml_dir_to_store: Optional[str] = None,
-        file_name: Optional[str] = None, binary_data=None,
-        file_dict: Dict[str, bytes] = None):
-    global _logger
-
-    assert binary_data
-    assert file_name
-
-    bytes_io = io.BytesIO(binary_data)
-
-    if xml_dir_to_store is not None:
-        if not os.path.exists(xml_dir_to_store):
-            os.makedirs(xml_dir_to_store)
-    else:
-        xml_dir_to_store = tempfile.mkdtemp(
-            prefix=datetime.now().strftime('%Y%m%d%H%M%S_'))
-
-    _file_name = ntpath.basename(file_name)
-    file_path = os.path.join(xml_dir_to_store, _file_name)
-
-    mode = 'w+'
-    data_to_write = bytes_io.getvalue()
-    if pathlib.Path(file_path).suffix.lower() != '.zip':
-        data_to_write = _drop_padding_data(
-            data_to_write, file_name=_file_name, file_dict=file_dict)
-
-    try:
-        with open(file_path, mode + 'b') as f:
-            f.write(data_to_write)
-    except UnicodeEncodeError:
-        # Probably you've caught "UnicodeEncodeError: 'charmap' codec can't
-        # encode characters"; the file must be a text file:
-        try:
-            with io.open(file_path, mode, encoding="utf-8") as f:
-                f.write(data_to_write)
-        except:
-            e = sys.exc_info()[0]
-            _logger.error(e, exc_info=True)
-            raise
-    except:
-        e = sys.exc_info()[0]
-        _logger.error(e, exc_info=True)
-        raise
-    else:
-        _logger.debug("created: {}".format(file_path))
-
-    return file_path
-
-
-def _drop_padding_data(
-        data_to_write: bytes, *, file_name: str = None,
-        file_dict: Dict[str, bytes] = None):
-    global _logger
-
-    assert data_to_write
-
-    data_to_be_found = b'\x00'
-    if file_dict and file_name:
-        result = None
-        key = None
-        for pattern in file_dict.keys():
-            result = re.search(pattern, file_name)
-            if result:
-                key = pattern
-                break
-        if result and key:
-            data_to_be_found = file_dict[key]
-
-    pos = data_to_write.find(data_to_be_found)
-    if pos != -1:
-        _logger.debug(
-            "an x00 has been found in {}; "
-            "the array will be truncated.".format(file_name))
-        return data_to_write[:pos]
-    else:
-        return data_to_write
 
 
 class _CallbackDestroyImageAcquirer(Callback):


### PR DESCRIPTION
The interface node map is used to call ForceIP for the device. ForceIP should be possible to call before connecting to the camera, however the interface node map isn't available until after an image acquirer is created. Creating an image acquirer will connect to the camera meaning that ForceIP currently can't be called before connecting.

My fix for this is to move the methods responsible for fetching the node map away from the image acquirer class. From what I have seen there is no reason that they have to be a part of it, and keeping them separated allows for creating the node map, and calling ForceIP before connecting to the device. I modified the methods as little as possible, only removing "self" as an input argument for the methods.  

I somewhat arbitrarily moved the methods to the port.py file since it's relevant to them, however they could be moved to wherever it makes the most sense to keep them. It might also be worthwhile to rename some of them if they are going to be more visible to users.

Here is an example of how I can use ForceIP after this change:

from harvesters.core import Harvester
from harvesters._private.core.port import _get_port_connected_node_map as get_node_map

h = Harvester()
h.add_file('UsedCtiFile.cti')
h.update()

node_map = get_node_map(h._interfaces[1].port)
    
node_map.GevDeviceForceIPAddress.value = new_address
node_map.GevDeviceForceIP.execute()