### PR TITLE
323 bump major version for non backward compatible api changes

### DIFF
--- a/src/harvesters/core.py
+++ b/src/harvesters/core.py
@@ -182,7 +182,7 @@ def _family_tree(node, tree=""):
     return tree
 
 
-def _pending_deprecation_warning(deprecated: object, alternative: object) -> None:
+def _indicate_deprecation(deprecated: object, alternative: object) -> None:
     #
     items = []
     for obj in (deprecated, alternative):
@@ -192,7 +192,7 @@ def _pending_deprecation_warning(deprecated: object, alternative: object) -> Non
         'please consider to use {} instead of {}.'.format(
             items[1], items[0]
         ),
-        PendingDeprecationWarning, stacklevel=3
+        DeprecationWarning, stacklevel=3
     )
 
 
@@ -1805,7 +1805,7 @@ class ImageAcquirer:
             :meth:`is_acquiring_images` will be removed in 2.0.0, it will
             be replaced by :meth:`is_acquiring`.
         """
-        _pending_deprecation_warning(self.is_acquiring_images, self.is_acquiring)
+        _indicate_deprecation(self.is_acquiring_images, self.is_acquiring)
         return self.is_acquiring()
 
     def is_acquiring(self) -> bool:
@@ -1841,12 +1841,12 @@ class ImageAcquirer:
             :attr:`timeout_on_client_fetch_call` will be removed in 2.0.0,
             it will be replaced by :attr:`timeout_period_on_client_fetch_call`.
         """
-        _pending_deprecation_warning('timeout_on_client_fetch_call', 'timeout_period_on_client_fetch_call')
+        _indicate_deprecation('timeout_on_client_fetch_call', 'timeout_period_on_client_fetch_call')
         return self.timeout_period_on_client_fetch_call
 
     @timeout_on_client_fetch_call.setter
     def timeout_on_client_fetch_call(self, value: float):
-        _pending_deprecation_warning('timeout_on_client_fetch_call', 'timeout_period_on_client_fetch_call')
+        _indicate_deprecation('timeout_on_client_fetch_call', 'timeout_period_on_client_fetch_call')
         self.timeout_period_on_client_fetch_call = value
 
     @property
@@ -1896,12 +1896,12 @@ class ImageAcquirer:
             :attr:`timeout_for_image_acquisition` will be removed in 2.0.0,
             it will be replaced by :attr:`timeout_period_on_update_event_data_call`.
         """
-        _pending_deprecation_warning('timeout_for_image_acquisition', 'timeout_period_on_update_event_data_call')
+        _indicate_deprecation('timeout_for_image_acquisition', 'timeout_period_on_update_event_data_call')
         return self._timeout_on_internal_fetch_call
 
     @timeout_for_image_acquisition.setter
     def timeout_for_image_acquisition(self, ms):
-        _pending_deprecation_warning('timeout_for_image_acquisition', 'timeout_period_on_update_event_data_call')
+        _indicate_deprecation('timeout_for_image_acquisition', 'timeout_period_on_update_event_data_call')
         self._timeout_on_internal_fetch_call = ms
 
     @property
@@ -1952,7 +1952,7 @@ class ImageAcquirer:
             :meth:`start_image_acquisition` will be removed in 2.0.0, it is
             replaced by :meth:`start`.
         """
-        _pending_deprecation_warning(self.start_image_acquisition, self.start_acquisition)
+        _indicate_deprecation(self.start_image_acquisition, self.start_acquisition)
         self.start_acquisition(run_in_background=run_in_background)
 
     def start_acquisition(self, run_in_background: bool = False) -> None:
@@ -1961,7 +1961,7 @@ class ImageAcquirer:
             :meth:`start_acquisition` will be removed in 2.0.0, it will be replaced
             by :meth:`start`.
         """
-        _pending_deprecation_warning(self.start_acquisition, self.start)
+        _indicate_deprecation(self.start_acquisition, self.start)
         self.start(run_as_thread=run_in_background)
 
     def start(self, *, run_as_thread: bool = False) -> None:
@@ -2268,7 +2268,7 @@ class ImageAcquirer:
             :meth:`fetch_buffer` will be removed in 2.0.0, it will be replaced
             by :meth:`fetch`.
         """
-        _pending_deprecation_warning(self.fetch_buffer, self.fetch)
+        _indicate_deprecation(self.fetch_buffer, self.fetch)
         return self.fetch(timeout=timeout, is_raw=is_raw, cycle_s=cycle_s)
 
     def fetch(self, *, timeout: float = 0, is_raw: bool = False,
@@ -2382,7 +2382,7 @@ class ImageAcquirer:
             :meth:`stop_image_acquisition` will be removed in 2.0.0, it is
             replaced by :meth:`stop`.
         """
-        _pending_deprecation_warning(self.stop_image_acquisition, self.stop)
+        _indicate_deprecation(self.stop_image_acquisition, self.stop)
         self.stop_acquisition()
 
     def stop_acquisition(self) -> None:
@@ -2391,7 +2391,7 @@ class ImageAcquirer:
             :meth:`stop_acquisition` will be removed in 2.0.0, it will be replaced
             by :meth:`stop`.
         """
-        _pending_deprecation_warning(self.stop_acquisition, self.stop)
+        _indicate_deprecation(self.stop_acquisition, self.stop)
         self.stop()
 
     def stop(self) -> None:
@@ -2677,7 +2677,7 @@ class Harvester:
             :attr:`cti_files` will be removed in 2.0.0, it will be replaced
             by :attr:`files`.
         """
-        _pending_deprecation_warning('cti_files', 'files')
+        _indicate_deprecation('cti_files', 'files')
         return self.files
 
     @property
@@ -2884,7 +2884,7 @@ class Harvester:
 
         """
         global _logger
-        _pending_deprecation_warning(self.create_image_acquirer, self.create)
+        _indicate_deprecation(self.create_image_acquirer, self.create)
         if not self.device_info_list:
             return None
 
@@ -2947,7 +2947,7 @@ class Harvester:
             :meth:`add_cti_file` will be removed in 2.0.0, it will be replaced
             by :meth:`add_file`.
         """
-        _pending_deprecation_warning(self.add_cti_file, self.add_file)
+        _indicate_deprecation(self.add_cti_file, self.add_file)
         self.add_file(file_path)
 
     def add_file(
@@ -3003,7 +3003,7 @@ class Harvester:
             :meth:`remove_cti_file` will be removed in 2.0.0, it will be replaced
             by :meth:`remove_file`.
         """
-        _pending_deprecation_warning(self.remove_cti_file, self.remove_file)
+        _indicate_deprecation(self.remove_cti_file, self.remove_file)
         self.remove_file(file_path)
 
     def remove_file(self, file_path: str) -> None:
@@ -3027,7 +3027,7 @@ class Harvester:
             :meth:`remove_cti_files` will be removed in 2.0.0, it will be replaced
             by :meth:`remove_files`.
         """
-        _pending_deprecation_warning(self.remove_cti_files, self.remove_files)
+        _indicate_deprecation(self.remove_cti_files, self.remove_files)
         self.remove_files()
 
     def remove_files(self) -> None:
@@ -3144,7 +3144,7 @@ class Harvester:
             :meth:`update_device_info_list` will be removed in 2.0.0, it will
             be replaced by :meth:`update`.
         """
-        _pending_deprecation_warning(self.update_device_info_list, self.update)
+        _indicate_deprecation(self.update_device_info_list, self.update)
         self.update()
 
     def update(self) -> None:

--- a/src/harvesters/test/base_harvester.py
+++ b/src/harvesters/test/base_harvester.py
@@ -19,6 +19,7 @@
 
 
 # Standard library imports
+from enum import IntEnum
 from logging import INFO
 import os
 import sys
@@ -30,6 +31,11 @@ import unittest
 from harvesters.core import Harvester, ParameterSet, ParameterKey
 from harvesters.util.logging import get_logger
 from harvesters.test.helper import get_package_dir
+
+
+class BaseVersion:
+    VERSION_LATEST = -1,
+    VERSION_1 = 1,
 
 
 def get_cti_file_path():
@@ -54,16 +60,15 @@ def get_cti_file_path():
     
     return cti_file_path
     
-    
+
 class TestHarvesterBase(unittest.TestCase):
     _cti_file_path = get_cti_file_path()
     sys.path.append(_cti_file_path)
+    base_version = BaseVersion.VERSION_LATEST
 
     def __init__(self, *args, **kwargs):
         #
         super().__init__(*args, **kwargs)
-
-        #
         self._harvester = None
         self._ia = None
         self._thread = None
@@ -118,38 +123,43 @@ class TestHarvesterBase(unittest.TestCase):
 
 class TestHarvester(TestHarvesterBase):
     def __init__(self, *args, **kwargs):
-        #
         super().__init__(*args, **kwargs)
 
     def setUp(self):
-        #
         super().setUp()
+        if self.base_version == BaseVersion.VERSION_LATEST:
+            config = ParameterSet({
+                ParameterKey.LOGGER: self._logger,
+                ParameterKey.ENABLE_CLEANING_UP_INTERMEDIATE_FILES: True,
+            })
+            self._harvester = Harvester(config=config)
+        elif self.base_version == BaseVersion.VERSION_1:
+            self._harvester = Harvester(logger=self._logger, do_clean_up=True)
+        else:
+            raise ValueError("invalid base version")
 
-        #
-        config = ParameterSet({
-            ParameterKey.LOGGER: self._logger,
-            ParameterKey.ENABLE_CLEANING_UP_INTERMEDIATE_FILES: True,
-        })
-        self._harvester = Harvester(config=config)
         self._harvester.add_file(self._cti_file_path)
         self._harvester.update()
 
 
 class TestHarvesterNoCleanUp(TestHarvesterBase):
     def __init__(self, *args, **kwargs):
-        #
         super().__init__(*args, **kwargs)
 
     def setUp(self):
-        #
         super().setUp()
+        if self.base_version == BaseVersion.VERSION_LATEST:
+            config = ParameterSet({
+                ParameterKey.LOGGER: self._logger,
+                ParameterKey.ENABLE_CLEANING_UP_INTERMEDIATE_FILES: False,
+            })
+            self._harvester = Harvester(config=config)
+        elif self.base_version == BaseVersion.VERSION_1:
+            self._harvester = Harvester(logger=self._logger,
+                                        do_clean_up=False)
+        else:
+            raise ValueError("invalid base version")
 
-        #
-        config = ParameterSet({
-            ParameterKey.LOGGER: self._logger,
-            ParameterKey.ENABLE_CLEANING_UP_INTERMEDIATE_FILES: False,
-        })
-        self._harvester = Harvester(config=config)
         self._harvester.add_file(self._cti_file_path)
         self._harvester.update()
 

--- a/src/harvesters/test/test_acq_frame_rate.py
+++ b/src/harvesters/test/test_acq_frame_rate.py
@@ -28,6 +28,7 @@ import unittest
 
 # Local application/library specific imports
 from harvesters.test.base_harvester import TestHarvester
+from harvesters.test.base_harvester import BaseVersion
 
 
 class ThreadWithTimeLimit(Thread):
@@ -159,6 +160,14 @@ class TestTutorials(TestHarvester):
 
         # Destroy the image acquirer:
         self.ia.destroy()
+
+
+class ThreadWithTimeLimitVersion1(ThreadWithTimeLimit):
+    base_version = BaseVersion.VERSION_1
+
+
+class TestTutorialsVersion1(TestTutorials):
+    base_version = BaseVersion.VERSION_1
 
 
 if __name__ == '__main__':

--- a/src/harvesters/test/test_harvester_core.py
+++ b/src/harvesters/test/test_harvester_core.py
@@ -55,6 +55,7 @@ from harvesters.util.pfnc import Mono10Packed, Mono12Packed
 from harvesters.util.pfnc import Mono10p, Mono12p, Mono14p
 from harvesters.util.pfnc import RGB10p, BGR10p
 from harvesters.util.pfnc import RGB12p, BGR12p
+from harvesters.test.base_harvester import BaseVersion
 
 
 class TestHarvesterCoreNoCleanUp(TestHarvesterNoCleanUp):
@@ -1000,6 +1001,7 @@ class TestIssue81(unittest.TestCase):
 class TestIssue85(unittest.TestCase):
     _cti_file_path = get_cti_file_path()
     sys.path.append(_cti_file_path)
+    base_version = BaseVersion.VERSION_LATEST
 
     def setUp(self) -> None:
         #
@@ -1027,17 +1029,21 @@ class TestIssue85(unittest.TestCase):
         #
         self.assertFalse(os.listdir(temp_dir))
 
-        config = ParameterSet({
-            ParameterKey.ENABLE_CLEANING_UP_INTERMEDIATE_FILES: False,
-        })
-        #
-        with Harvester(config=config) as h:
-            h.add_file(self._cti_file_path)
-            h.update()
-            with h.create_image_acquirer(0):
-                # Check if XML files have been stored in the expected
-                # directory:
-                self.assertTrue(os.listdir(temp_dir))
+        if self.base_version == BaseVersion.VERSION_LATEST:
+            config = ParameterSet({
+                ParameterKey.ENABLE_CLEANING_UP_INTERMEDIATE_FILES: False,
+            })
+            h = Harvester(config=config)
+        else:
+            h = Harvester(do_clean_up=False)
+
+        h.add_file(self._cti_file_path)
+        h.update()
+        with h.create_image_acquirer(0):
+            # Check if XML files have been stored in the expected
+            # directory:
+            self.assertTrue(os.listdir(temp_dir))
+        h.reset()
 
 
 class _OnNewBufferAvailable(Callback):
@@ -1187,8 +1193,24 @@ class TestUtility(unittest.TestCase):
         prefix = 'file:///'
         path = 'C:/ProgramData/GenICam/xml/cache/Optronis_Cyclone_V1_7_8.xml'
         url = prefix + path
-        result = ImageAcquirer._retrieve_file_path(url=url)
+        result = Module._retrieve_file_path(url=url)
         self.assertEqual(path, result)
+
+
+class TestHarvesterCoreNoCleanUpVersion1(TestHarvesterCoreNoCleanUp):
+    base_version = BaseVersion.VERSION_1
+
+
+class TestHarvesterCoreVersion1(TestHarvesterCore):
+    base_version = BaseVersion.VERSION_1
+
+
+class TestIssue85Version1(TestIssue85):
+    base_version = BaseVersion.VERSION_1
+
+
+class TestIssue181Version1(TestIssue181):
+    base_version = BaseVersion.VERSION_1
 
 
 if __name__ == '__main__':

--- a/src/harvesters/test/test_tutorials.py
+++ b/src/harvesters/test/test_tutorials.py
@@ -29,6 +29,7 @@ from harvesters.core import Harvester
 # Local application/library specific imports
 from harvesters.test.base_harvester import TestHarvester
 from harvesters.test.base_harvester import get_cti_file_path
+from harvesters.test.base_harvester import BaseVersion
 
 
 class AcquisitionThread(Thread):
@@ -183,6 +184,10 @@ class TestTutorials2(unittest.TestCase):
 
         # We don't need the ImageAcquirer object. Destroy it:
         ia.destroy()
+
+
+class TestTutorialsVersion1(TestTutorials):
+    base_version = BaseVersion.VERSION_1
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Recovers the dropped public API items so that we can keep the backward compatibility; note that the recovered items are tagged as deprecated still now and from now on.