### PR TITLE
Revert changes from 31ca2807a0668b328114d7a37e95c0bdec4412ee

### DIFF
--- a/src/harvesters/core.py
+++ b/src/harvesters/core.py
@@ -2732,6 +2732,10 @@ class ImageAcquirer:
         for data_stream in self._data_streams:
             if data_stream.is_open():
                 self._flush_buffers(data_stream)
+                for buffer in self._announced_buffers:
+                    name = _family_tree(buffer)
+                    _ = data_stream.revoke_buffer(buffer)
+                    _logger.debug('revoked: {0}'.format(name))
 
         self._announced_buffers.clear()
 


### PR DESCRIPTION
Do not revoke the buffer results in memory leak.
fix #399

With this change I was not able to reproduce the issue (#390) which was originally addressed to be fixed by the commit (31ca2807a0668b328114d7a37e95c0bdec4412ee). As well as the commend https://github.com/genicam/harvesters/issues/390#issuecomment-1419291968 is not true. A call to `DSFlushQueue` with `ACQ_QUEUE_ALL_DISCARD` doesn't revoke the buffers.

Quote of the GenTL documentation for `ACQ_QUEUE_ALL_DISCARD`

> Discards all buffers in the input pool and the buffers in the output queue including buffers currently being filled so that no buffer is bound to any internal mechanism and all buffers may be revoked or requeued.

And the `DSAnnounceBuffer` documentation defines a required call of _revoke_

> Every call of this function must be matched with a call of DSRevokeBuffer