### PR TITLE
Harvesters Core|Change: replaced deprecated name timeout_on_client_fetch_call

### DIFF
--- a/src/harvesters/core.py
+++ b/src/harvesters/core.py
@@ -1699,7 +1699,7 @@ class ImageAcquirer:
         self._num_images_to_acquire = 0
 
         self._timeout_on_internal_fetch_call = ParameterSet.get(ParameterKey.TIMEOUT_PERIOD_ON_UPDATE_EVENT_DATA_CALL, 1, config)  # ms
-        self._timeout_on_client_fetch_call = ParameterSet.get(ParameterKey.TIMEOUT_PERIOD_ON_CLIENT_FETCH_CALL, 0.01, config)  # s
+        self._timeout_period_on_client_fetch_call = ParameterSet.get(ParameterKey.TIMEOUT_PERIOD_ON_CLIENT_FETCH_CALL, 0.01, config)  # s
 
         self._statistics = Statistics()
         self._announced_buffers = []
@@ -2060,7 +2060,7 @@ class ImageAcquirer:
         float: It is used to define the timeout duration on a single fetch
         method calL. The unit is [s].
         """
-        return self._timeout_on_client_fetch_call
+        return self._timeout_period_on_client_fetch_call
 
     @timeout_period_on_client_fetch_call.setter
     def timeout_period_on_client_fetch_call(self, value: float):
@@ -2072,7 +2072,7 @@ class ImageAcquirer:
         else:
             if client < internal:
                 _logger.warning("may cause timeout: {}".format(info))
-        self._timeout_on_client_fetch_call = value
+        self._timeout_period_on_client_fetch_call = value
 
     @property
     def timeout_period_on_update_event_data_call(self) -> int:
@@ -2311,7 +2311,7 @@ class ImageAcquirer:
 
         for monitor in self._new_buffer_event_monitor_dict.values():
             buffer = self._fetch(monitor=monitor,
-                                 timeout_on_client_fetch_call=self.timeout_on_client_fetch_call)
+                                 timeout_period_on_client_fetch_call=self.timeout_period_on_client_fetch_call)
             if buffer:
                 with MutexLocker(self._event_new_buffer_thread):
                     if not self._is_acquiring:
@@ -2400,7 +2400,7 @@ class ImageAcquirer:
         buffers = []
         for monitor in self._new_buffer_event_monitor_dict.values():
             buffer = self._fetch(monitor=monitor,
-                                 timeout_on_client_fetch_call=timeout,
+                                 timeout_period_on_client_fetch_call=timeout,
                                  throw_except=False)
 
             buffers.append(self._finalize_fetching_process(buffer, is_raw))
@@ -2408,24 +2408,24 @@ class ImageAcquirer:
         return buffers if len(self._new_buffer_event_monitor_dict.values()) > 1 else buffers[0]
 
     def _fetch(self, *, monitor: EventManagerNewBuffer,
-               timeout_on_client_fetch_call: float = 0,
+               timeout_period_on_client_fetch_call: float = 0,
                throw_except: bool = False) -> Union[Buffer, _Buffer, None]:
         global _logger
 
         assert monitor
 
         buffer = None
-        watch_timeout = True if timeout_on_client_fetch_call > 0 else False
+        watch_timeout = True if timeout_period_on_client_fetch_call > 0 else False
         base = time.time()
 
         while not buffer:
             if watch_timeout:
                 elapsed = time.time() - base
-                if elapsed > timeout_on_client_fetch_call:
+                if elapsed > timeout_period_on_client_fetch_call:
                     if _is_logging_buffer:
                         _logger.debug(
                             'timeout: elapsed {0} sec.'.format(
-                                timeout_on_client_fetch_call))
+                                timeout_period_on_client_fetch_call))
                     if throw_except:
                         raise TimeoutException
                     else:
@@ -2558,7 +2558,7 @@ class ImageAcquirer:
                 while not buffer:
                     try:
                         buffer = self._fetch(monitor=monitor,
-                                             timeout_on_client_fetch_call=timeout,
+                                             timeout_period_on_client_fetch_call=timeout,
                                              throw_except=True)
                     except GenTL_GenericException:
                         raise

--- a/src/harvesters/test/test_harvester_core.py
+++ b/src/harvesters/test/test_harvester_core.py
@@ -912,24 +912,24 @@ class TestHarvesterCore(TestHarvester):
         self._logger.info("larger")
         value = internal + 1
         value /= 1000
-        self.ia.timeout_on_client_fetch_call = value
+        self.ia.timeout_period_on_client_fetch_call = value
 
         self._logger.info("equal")
         value = 0.001
-        self.ia.timeout_on_client_fetch_call = value
+        self.ia.timeout_period_on_client_fetch_call = value
 
         self._logger.info("smaller")
         value = internal * 1000
         value -= 1
         value /= 1000
         value /= 1000
-        self.ia.timeout_on_client_fetch_call = value
+        self.ia.timeout_period_on_client_fetch_call = value
 
     def test_fix_for_bfd47ca_2(self):
         # Create an image acquirer:
         self.ia = self.harvester.create_image_acquirer(0)
 
-        self.ia.timeout_on_client_fetch_call = 2.
+        self.ia.timeout_period_on_client_fetch_call = 2.
         self._logger.info("larger")
         self.ia.timeout_period_on_update_event_data_call = 2001
         self._logger.info("equal")


### PR DESCRIPTION
 Replaced all instances of deprecated name timeout_on_client_fetch_call with timeout_period_on_client_fetch_call