### PR TITLE
fix deprecated numpy thruth value expression

### DIFF
--- a/src/harvesters/core.py
+++ b/src/harvesters/core.py
@@ -989,7 +989,7 @@ class Component2DImage(Component):
         Union[numpy.ndarray, None]
             A NumPy array that represents the 2D pixel location.
         """
-        if not self.data:
+        if self.data is None or self.data.size == 0:
             return None
 
         return self._data.reshape(


### PR DESCRIPTION
Since the numpy version 1.14 expressions like: `if not self.data:` for checking both if the object is None and if the array is empty is deprecated and since later versions it throws a ValueError. I updated the line in represent_pixel_location() to handle later numpy versions.