### PR TITLE
Handle InvalidHandleException when creating ImageAcquirer

### DIFF
--- a/src/harvesters/core.py
+++ b/src/harvesters/core.py
@@ -59,7 +59,7 @@ from genicam.genapi import EventAdapterGEV, EventAdapterU3V, \
 
 from genicam.gentl import TimeoutException, NotAvailableException
 from genicam.gentl import GenericException as GenTL_GenericException, \
-    NotImplementedException, ResourceInUseException, InvalidParameterException
+    NotImplementedException, ResourceInUseException, InvalidParameterException, InvalidHandleException
 from genicam.gentl import GenTLProducer, BufferToken
 from genicam.gentl import EventManagerNewBuffer, EventManagerRemoteDevice, \
     EventManagerModule
@@ -1669,6 +1669,8 @@ class ImageAcquirer:
                 _logger.debug("resource in use: {}".format(module))
             except InvalidParameterException:
                 _logger.debug("invalid parameter: {}".format(module))
+            except InvalidHandleException:
+                _logger.debug("invalid handle: {}".format(module))
             else:
                 self._module_event_monitor_thread_dict[module] = \
                     self._thread_factory_method_for_event_module()


### PR DESCRIPTION
This fixes the regression that happened between v1.4.0 and v1.4.1.

Issue: [Regression: v1.4.1 causes an exception, v1.4.0 works](https://github.com/genicam/harvesters/issues/436)